### PR TITLE
added multi-regions support, added example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ A single CloudWatch Event Rule takes care of listening for RDS Snapshots Events 
 * Since the module (optionally) creates its own KMS CMK, keep that in mind regarding KMS pricing; not only regarding the pricing of a single key, but also things like key rotations/versions and KMS API requests.
 * The module requires you to provide the S3 bucket that will be used for storing the exported snapshots. The good thing about this is that you are able to configure the bucket in any way you need. E.g. replication, lifecycle, locking, and so on.
 * The module can create an export monitor SNS notification topic, also existing SNS topics are supported via `notifications_topic_arn` variable.
+* Multi-region support via terraform providers.
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 
 ## Providers
 
@@ -35,8 +38,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_monitor_export_task_lambda"></a> [monitor\_export\_task\_lambda](#module\_monitor\_export\_task\_lambda) | github.com/terraform-aws-modules/terraform-aws-lambda | v2.7.0 |
-| <a name="module_start_export_task_lambda"></a> [start\_export\_task\_lambda](#module\_start\_export\_task\_lambda) | github.com/terraform-aws-modules/terraform-aws-lambda | v2.7.0 |
+| <a name="module_monitor_export_task_lambda"></a> [monitor\_export\_task\_lambda](#module\_monitor\_export\_task\_lambda) | github.com/terraform-aws-modules/terraform-aws-lambda | v2.23.0 |
+| <a name="module_start_export_task_lambda"></a> [start\_export\_task\_lambda](#module\_start\_export\_task\_lambda) | github.com/terraform-aws-modules/terraform-aws-lambda | v2.23.0 |
 
 ## Resources
 
@@ -69,7 +72,8 @@ No requirements.
 | <a name="input_database_names"></a> [database\_names](#input\_database\_names) | The names of the databases whose snapshots we want to export to S3. Comma-separated values), ex: `"db-cluster1, db-cluster2"` | `string` | `null` | yes |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | The log level of the Lambda function. | `string` | `"INFO"` | no |
 | <a name="input_notifications_topic_arn"></a> [notifications\_topic\_arn](#input\_notifications\_topic\_arn) | The ARN of an SNS Topic which will be used for publishing notifications messages. Required if `create_notifications_topic` is set to `false`. | `string` | `null` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix that will be used for naming resources. | `string` | `null` | no |
+| <a name="input_postfix"></a> [postfix](#input\_postfix) | Postfix that will be used for naming resources. `resouce-name-<postfix>`.| `string` | `<region>` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix that will be used for naming resources. `<prefix>-resouce-name`. | `string` | `null` | no |
 | <a name="input_rds_event_ids"></a> [rds\_event\_id](#input\_rds\_event\_ids) | RDS (CloudWatch) Event IDs that will trigger the calling of RDS Start Export Task API:<br>- Automated snapshots of Aurora RDS: RDS-EVENT-0169<br>- Automated snapshots of non-Aurora RDS: RDS-EVENT-0091<br>Only automated backups of either RDS Aurora and RDS non-Aurora are supported.<br>Ref: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.Messages.html#USER_Events.Messages.snapshot<br>Ref: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Events.Messages.html#USER_Events.Messages.cluster-snapshot. | `string` | `"RDS-EVENT-0091, RDS-EVENT-0169"` | no |
 | <a name="input_snapshots_bucket_name"></a> [snapshots\_bucket\_name](#input\_snapshots\_bucket\_name) | The name of the bucket where the RDS snapshots will be exported to. | `string` | `null` | yes |
 | <a name="input_snapshots_bucket_prefix"></a> [snapshots\_bucket\_prefix](#input\_snapshots\_bucket\_prefix) | The Amazon S3 bucket prefix to use as the file name and path of the exported snapshot. For example, use the prefix `"exports/2019/"`. | `string` | `null` | yes |

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -2,7 +2,7 @@
 # Create an event rule to listen for RDS DB Cluster Snapshot Events
 #
 resource "aws_cloudwatch_event_rule" "rdsSnapshotCreation" {
-  name        = "${local.prefix}rds-snapshot-creation"
+  name        = "${local.prefix}rds-snapshot-creation${local.postfix}"
   description = "RDS Snapshot Creation"
 
   event_pattern = <<PATTERN
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_event_rule" "rdsSnapshotCreation" {
 }
 PATTERN
 
-  tags = merge({ Name = "${local.prefix}rds-snapshot-creation" }, var.tags)
+  tags = merge({ Name = "${local.prefix}rds-snapshot-creation${local.postfix}" }, var.tags)
 }
 
 #

--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -1,0 +1,192 @@
+# -----------------------------------------------------------------------------
+# Providers
+# -----------------------------------------------------------------------------
+
+#region1
+provider "aws" {
+  region = "eu-west-2"
+}
+
+#region2
+provider "aws" {
+  region = "us-east-1"
+  alias  = "region2"
+}
+
+# -----------------------------------------------------------------------------
+# local variables
+# -----------------------------------------------------------------------------
+
+locals {
+  bucket_name_region1 = "example-rds-exported-snapshots-region1"
+  bucket_name_region2 = "example-rds-exported-snapshots-region2"
+  tags_region1 = {
+    Name      = "example"
+    Terraform = "true"
+    Region    = "eu-west-2"
+  }
+  tags_region2 = {
+    Name      = "example"
+    Terraform = "true"
+    Region    = "us-east-1"
+  }
+
+}
+
+# -----------------------------------------------------------------------------
+# RDS Export To S3 functions
+# -----------------------------------------------------------------------------
+module "rds_export_to_s3_region1" {
+  source = "../../"
+
+  # AWS Provider/alias. Multi-regions support via provider alias. e.g. 'aws.region2'
+  #providers = {
+  #  aws = aws
+  #}
+
+  # Set a prefix for naming resources. '<prefix>resouce-name'. 
+  #prefix = "binbashar"
+
+  # Set a postfix for naming resources. 'resouce-name-<postfix>'. Default is current region (${data.aws_region.current.name}).
+  #postfix = "<region>"
+
+  # Which RDS snapshots should be exported?
+  database_names = "test1-aurora-mysql-cluster, test2-aurora-mysql-cluster"
+
+  # Which bucket will store the exported snapshots?
+  snapshots_bucket_name = module.bucket-region1.s3_bucket_id
+  #snapshots_bucket_name = "export-bucket-name"
+
+  # To group objects in a bucket, S3 uses a prefix before object names. The forward slash (/) in the prefix represents a folder.
+  snapshots_bucket_prefix = "rds_snapshots/"
+
+  # Which RDS snapshots events should be included (RDS Aurora or/and RDS non-Aurora)?
+  #rds_event_ids = "RDS-EVENT-0091, RDS-EVENT-0169"
+
+  # Create customer managed key or use default AWS S3 managed key. If set to 'false', then 'customer_kms_key_arn' is used.
+  create_customer_kms_key = true
+
+  # Provide CMK if 'create_customer_kms_key = false'
+  #customer_kms_key_arn = "arn:aws:kms:eu-west-2:123456789:alias/kms-rds"
+
+  # SNS topic for export monitor notifications
+  create_notifications_topic = true
+
+  # Which topic should receive notifications about exported snapshots events? Only required if 'create_notifications_topic = false'
+  #notifications_topic_arn = "arn:aws:sns:us-east-1:000000000000:sns-topic-slack-notifications"
+
+  # Set the logging level
+  # log_level = "DEBUG"
+
+  tags = local.tags_region1
+  #tags = { Deployment = "binbachar-export-region-1" }
+}
+
+
+module "rds_export_to_s3_region2" {
+  source = "../../"
+
+  # AWS Provider/alias. Multi-regions support via provider alias. e.g. 'aws.us-east-1'.
+  providers = {
+    aws = aws.region2
+  }
+
+  # Set a prefix for naming resources. '<prefix>resouce-name'.
+  #prefix = "binbashar"
+
+  # Set a postfix for naming resources. 'resouce-name-<postfix>'. Default is current region (${data.aws_region.current}).
+  #postfix = "<region>"
+
+  # Which RDS snapshots should be exported?
+  database_names = "test3-aurora-mysql-cluster, test4-aurora-mysql-cluster"
+
+  # Which bucket will store the exported snapshots?
+  snapshots_bucket_name = module.bucket-region2.s3_bucket_id
+  #snapshots_bucket_name = "export-bucket-name"
+
+  # To group objects in a bucket, S3 uses a prefix before object names. The forward slash (/) in the prefix represents a folder.
+  snapshots_bucket_prefix = "rds_snapshots/"
+
+  # Which RDS snapshots events should be included (RDS Aurora or/and RDS non-Aurora)?
+  #rds_event_ids = "RDS-EVENT-0091, RDS-EVENT-0169"
+
+  # Create customer managed key or use default AWS S3 managed key. If set to 'false', then 'customer_kms_key_arn' is used.
+  create_customer_kms_key = false
+
+  # Provide CMK if 'create_customer_kms_key = false'
+  customer_kms_key_arn = "arn:aws:kms:us-east-1:123456789:alias/kms-rds"
+
+  # SNS topic for export monitor notifications
+  create_notifications_topic = true
+
+  # Which topic should receive notifications about exported snapshots events? Only required if 'create_notifications_topic = false'
+  #notifications_topic_arn = "arn:aws:sns:us-east-1:000000000000:sns-topic-slack-notifications"
+
+  # Set the logging level
+  # log_level = "DEBUG"
+
+  tags = local.tags_region1
+  #tags = { Deployment = "binbachar-export-region2" }
+}
+
+
+# -----------------------------------------------------------------------------
+# This bucket will be used for storing the exported RDS snapshots.
+# -----------------------------------------------------------------------------
+module "bucket-region1" {
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v2.6.0"
+
+  #main provider
+  #provider = aws
+
+  bucket        = local.bucket_name_region1
+  acl           = "private"
+  force_destroy = true
+
+  attach_deny_insecure_transport_policy = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  tags = local.tags_region1
+}
+
+
+module "bucket-region2" {
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v2.6.0"
+
+  #provider with alias, different region
+  provider = aws.region2
+
+  bucket        = local.bucket_name_region2
+  acl           = "private"
+  force_destroy = true
+
+  attach_deny_insecure_transport_policy = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  tags = local.tags_region1
+}
+

--- a/identities.tf
+++ b/identities.tf
@@ -2,8 +2,8 @@
 # This role is used by RDS Start Export Task
 #
 resource "aws_iam_role" "rdsSnapshotExportTask" {
-  name               = "${local.prefix}snapshot-export-task"
-  tags               = merge({ Name = "${local.prefix}snapshot-export-task" }, var.tags)
+  name               = "${local.prefix}snapshot-export-task${local.postfix}"
+  tags               = merge({ Name = "${local.prefix}snapshot-export-task${local.postfix}" }, var.tags)
   assume_role_policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -24,7 +24,7 @@ POLICY
 # Allow RDS Start Export Task to write the snapshot on the S3 bucket
 #
 resource "aws_iam_role_policy" "rdsSnapshotExportToS3" {
-  name   = "${local.prefix}rds-snapshot-export-to-s3"
+  name   = "${local.prefix}rds-snapshot-export-to-s3${local.postfix}"
   role   = aws_iam_role.rdsSnapshotExportTask.id
   policy = <<POLICY
 {
@@ -54,8 +54,8 @@ POLICY
 # Lambda Permissions: Start Export Task
 #
 resource "aws_iam_policy" "rdsStartExportTaskLambda" {
-  name   = "${local.prefix}rds-snapshot-exporter-lambda"
-  tags   = merge({ Name = "${local.prefix}rds-snapshot-exporter-lambda" }, var.tags)
+  name   = "${local.prefix}rds-snapshot-exporter-lambda${local.postfix}"
+  tags   = merge({ Name = "${local.prefix}rds-snapshot-exporter-lambda${local.postfix}" }, var.tags)
   policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -104,8 +104,8 @@ POLICY
 # Lambda Permissions: Export Task Monitor
 #
 resource "aws_iam_policy" "rdsMonitorExportTaskLambda" {
-  name   = "${local.prefix}rds-snapshot-exporter-monitor-lambda"
-  tags   = merge({ Name = "${local.prefix}rds-snapshot-exporter-monitor-lambda" }, var.tags)
+  name   = "${local.prefix}rds-snapshot-exporter-monitor-lambda${local.postfix}"
+  tags   = merge({ Name = "${local.prefix}rds-snapshot-exporter-monitor-lambda${local.postfix}" }, var.tags)
   policy = <<POLICY
 {
     "Version": "2012-10-17",

--- a/kms.tf
+++ b/kms.tf
@@ -4,7 +4,7 @@
 resource "aws_kms_key" "snapshotExportEncryptionKey" {
   count       = var.create_customer_kms_key ? 1 : 0
   description = "Snapshot Export Encryption Key"
-  tags        = merge({ Name = "Snapshot Export Encryption Key" }, var.tags)
+  tags        = merge({ Name = "${local.prefix}kms-rds-snapshot-key${local.postfix}" }, var.tags)
   policy      = <<POLICY
 {
     "Version": "2012-10-17",
@@ -59,6 +59,6 @@ POLICY
 #
 resource "aws_kms_alias" "snapshotExportEncryptionKey" {
   count         = var.create_customer_kms_key ? 1 : 0
-  name          = "alias/${local.prefix}rds-export-to-s3"
+  name          = "alias/${local.prefix}rds-snapshot-export${local.postfix}"
   target_key_id = aws_kms_key.snapshotExportEncryptionKey[0].key_id
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -3,9 +3,9 @@
 # database name and the event id for which this is configured.
 #
 module "start_export_task_lambda" {
-  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v2.7.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v2.23.0"
 
-  function_name = "${local.prefix}rds-export-to-s3"
+  function_name = "${local.prefix}rds-export-to-s3${local.postfix}"
   description   = "RDS Export To S3"
   handler       = "index.handler"
   runtime       = "python3.8"
@@ -28,16 +28,16 @@ module "start_export_task_lambda" {
   attach_policy = true
   policy        = aws_iam_policy.rdsStartExportTaskLambda.arn
 
-  tags = merge({ Name = "${local.prefix}rds-export-to-s3" }, var.tags)
+  tags = merge({ Name = "${local.prefix}rds-export-to-s3${local.postfix}" }, var.tags)
 }
 
 #
 # This function will react to rds snapshot export task events.
 #
 module "monitor_export_task_lambda" {
-  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v2.7.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v2.23.0"
 
-  function_name = "${local.prefix}rds-export-to-s3-monitor"
+  function_name = "${local.prefix}rds-export-to-s3-monitor${local.postfix}"
   description   = "RDS Export To S3 Monitor"
   handler       = "index.handler"
   runtime       = "python3.8"
@@ -56,5 +56,5 @@ module "monitor_export_task_lambda" {
   attach_policy = true
   policy        = aws_iam_policy.rdsMonitorExportTaskLambda.arn
 
-  tags = merge({ Name = "${local.prefix}rds-export-to-s3-monitor" }, var.tags)
+  tags = merge({ Name = "${local.prefix}rds-export-to-s3-monitor${local.postfix}" }, var.tags)
 }

--- a/topic.tf
+++ b/topic.tf
@@ -2,15 +2,15 @@
 # Create an SNS Topic for receiving RDS Snapshot Events
 #
 resource "aws_sns_topic" "rdsSnapshotsEvents" {
-  name = "${local.prefix}rds-snapshots-creation"
-  tags = merge({ Name = "${local.prefix}rds-snapshots-creation" }, var.tags)
+  name = "${local.prefix}rds-snapshots-creation${local.postfix}"
+  tags = merge({ Name = "${local.prefix}rds-snapshots-creation${local.postfix}" }, var.tags)
 }
 
 
 resource "aws_sns_topic" "exportMonitorNotifications" {
   count = var.create_notifications_topic ? 1 : 0
-  name  = "${local.prefix}rds-exports-monitor-notifications"
-  tags  = merge({ Name = "${local.prefix}rds-exports-monitor-notifications" }, var.tags)
+  name  = "${local.prefix}rds-exports-monitor-notifications${local.postfix}"
+  tags  = merge({ Name = "${local.prefix}rds-exports-monitor-notifications${local.postfix}" }, var.tags)
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,17 @@
 locals {
   snapshots_bucket_arn = "arn:aws:s3:::${var.snapshots_bucket_name}"
   prefix               = var.prefix != null ? "${var.prefix}-" : ""
+  postfix              = var.postfix != null ? "-${var.postfix}" : "-${data.aws_region.current.name}"
 }
 
 variable "prefix" {
-  description = "Prefix that will be used for naming resources."
+  description = "Prefix that will be used for naming resources. '<prefix>resouce-name'."
+  type        = string
+  default     = null
+}
+
+variable "postfix" {
+  description = "Postfix that will be used for naming resources. 'resouce-name-<postfix>'."
   type        = string
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+#
+# Pass over provider configurations for multi-region support 
+#
+terraform {
+  required_providers {
+    aws = ">= 3.19"
+  }
+}


### PR DESCRIPTION
- bumped github.com/terraform-aws-modules/terraform-aws-lambda v2.7.0 -> v2.23.0
- added multi-regions support via providers/aliases
- added multi-region example
- updated resource naming pattern to `${local.prefix}resource-name${local.postfix}` (default: `resource-name-<region>`) to avoid naming collisions with multi-regions