### PR TITLE
Fix export task id when it ends with a hyphen

### DIFF
--- a/functions/export-to-s3/index.py
+++ b/functions/export-to-s3/index.py
@@ -37,6 +37,8 @@ def handler(event, context):
             matchSnapshotRegEx = "^rds:" + db + "-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}$"
             if re.match(matchSnapshotRegEx, sourceId):
                 exportTaskId = ((sourceId[4:] + '-').replace("--", "-") + messageId)[:60]
+                if exportTaskId[59] == "-":
+                    exportTaskId = exportTaskId[:59]
                 response = boto3.client("rds").start_export_task(
                     ExportTaskIdentifier=exportTaskId,
                     SourceArn=sourceArn,


### PR DESCRIPTION
Hi all

I caught an error when I was testing this module earlier this week. After analyzing the logs, I realized that the export task id ended with a hyphen and the lambda function doesn't handle this situation.
I fixed it in this PR.
Thank you for your attention.

Best regards,
Marcos