### PR TITLE
Allow shorter db names

### DIFF
--- a/functions/export-to-s3/index.py
+++ b/functions/export-to-s3/index.py
@@ -37,8 +37,8 @@ def handler(event, context):
             matchSnapshotRegEx = "^rds:" + db + "-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}$"
             if re.match(matchSnapshotRegEx, sourceId):
                 exportTaskId = ((sourceId[4:] + '-').replace("--", "-") + messageId)[:60]
-                if exportTaskId[59] == "-":
-                    exportTaskId = exportTaskId[:59]
+                if exportTaskId[-1] == "-":
+                    exportTaskId = exportTaskId[:-1]
                 response = boto3.client("rds").start_export_task(
                     ExportTaskIdentifier=exportTaskId,
                     SourceArn=sourceArn,


### PR DESCRIPTION
This fixes issue I reported in #9.

The current implementation assumes a fixed length of the task ID. When the db name doesn't match the expected length, the Lambda fails. 

Using `-1` grabs the last character of the string. This allows for variable length task IDs.