### PR TITLE
Enhacement | Update lambda module

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -35,7 +35,7 @@ module "start_export_task_lambda" {
 # This function will react to rds snapshot export task events.
 #
 module "monitor_export_task_lambda" {
-  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v2.23.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v6.4.0"
 
   function_name = "${local.prefix}rds-export-to-s3-monitor${local.postfix}"
   description   = "RDS Export To S3 Monitor"

--- a/lambda.tf
+++ b/lambda.tf
@@ -3,7 +3,7 @@
 # database name and the event id for which this is configured.
 #
 module "start_export_task_lambda" {
-  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v2.23.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v6.4.0"
 
   function_name = "${local.prefix}rds-export-to-s3${local.postfix}"
   description   = "RDS Export To S3"


### PR DESCRIPTION
## What?

Update lambda module from `v2.23.0` to `v6.4.0`.

- resolve #15 

## Why?

The old version uses deprecated resources:

```
│ Warning: Argument is deprecated
│ 
│   with module.bucket.aws_s3_bucket.this[0],
│   on .terraform/modules/bucket/main.tf line 5, in resource "aws_s3_bucket" "this":
│    5: resource "aws_s3_bucket" "this" {
│ 
│ Use the aws_s3_bucket_server_side_encryption_configuration resource instead
│ 
│ (and one more similar warning elsewhere)
╵
```